### PR TITLE
アカウント作成時にリダイレクトされるURLを修正

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - "3000:3000"
     environment:
       <<: *langfuse-worker-env
-      NEXTAUTH_URL: http://0.0.0.0:3000
+      NEXTAUTH_URL: http://localhost:3000
       NEXTAUTH_SECRET: mysecret
       LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-}
       LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-}


### PR DESCRIPTION
## 対応内容
- Langfuse アカウント作成後に自動リダイレクトされるアドレスの指定がうまく機能していなかった為、修正を行いました。

## 確認内容
- Langfuse アカウント作成後にホストされていないサイトへアクセスされる事が修正されているか検証してほしい

## 備考
- 重要度低め