### PR TITLE
page_idを基にnotionのpageのurlを取得する処理の記述

### DIFF
--- a/dev/backend/api/notion/func.py
+++ b/dev/backend/api/notion/func.py
@@ -204,7 +204,6 @@ class NotionAPI:
 
         if status_code != 200:
             # urlの内容が取得できない場合はエラーコードを返す
-            pprint(res)
             return None, status_code
 
         page_url = response["url"]

--- a/dev/backend/api/notion/func.py
+++ b/dev/backend/api/notion/func.py
@@ -1,15 +1,16 @@
+import json
 import os
 import sys
-from dotenv import load_dotenv
-import requests
-import json
-from typing import List
 from pprint import pprint
+from typing import List, Optional, Tuple
+
+import requests
+from dotenv import load_dotenv
 
 # local
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))  # 2つ上の階層を指定
-from api.schema import *
 from api.notion.schema import PageModel
+from api.schema import *
 
 load_dotenv("../../../backend/.env")  # 環境変数をロード
 
@@ -192,6 +193,24 @@ class NotionAPI:
         # self.database_properties_id = properties_id  # プロパティIDを更新
         return list(properties_id.values()), status_code
 
+    def search_page_url(self, page_id: str) -> Tuple[Optional[str], int]:
+        """
+        page_idを基にNotion APIを用いてpageのurlを取得する
+        """
+        url = f"{self.url}/pages/{page_id}/"
+        response = requests.request("GET", url, headers=self.headers, timeout=30)
+        status_code = response.status_code
+        response = response.json()
+
+        if status_code != 200:
+            # urlの内容が取得できない場合はエラーコードを返す
+            pprint(res)
+            return None, status_code
+
+        page_url = response["url"]
+
+        return page_url, status_code
+
 
 if __name__ == "__main__":
     # テスト用
@@ -242,4 +261,12 @@ if __name__ == "__main__":
         )
         notion_api = NotionAPI(notion_item=notion_item)
         res = notion_api.search_database_id()
+        pprint(res)
+    elif run_test_num == 3:
+        print("■ test 2 : get_page_url")
+        test_access_token = input("access_token: ")
+        test_page_id = input("page_id: ")
+        notion_item = NotionItem(access_token=test_access_token)
+        notion_api = NotionAPI(notion_item=notion_item)
+        res = notion_api.search_page_url(page_id=test_page_id)
         pprint(res)

--- a/dev/backend/api/notion/func.py
+++ b/dev/backend/api/notion/func.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
         res = notion_api.search_database_id()
         pprint(res)
     elif run_test_num == 3:
-        print("■ test 2 : get_page_url")
+        print("■ test 3 : get_page_url")
         test_access_token = input("access_token: ")
         test_page_id = input("page_id: ")
         notion_item = NotionItem(access_token=test_access_token)


### PR DESCRIPTION
# タスク
[議事録閲覧機能](https://www.notion.so/0624d75239cb43c49bacaa01dbcf98c7)

# 作業ファイル
`backend/api/notion/func.py`

# 作業内容
`NotionAPI`クラスに`search_page_url`メソッドを追加した。
## search_page_urlの処理内容
`page_id`を引数として取得し、`page_url`と`status_code`を返り値として返す。

# 確認方法
`cd`コマンドで`backend/api/notion/`ディレクトリに行き、`rye run python func.py`で実行する。
`run test number`は`3`、`access_token`、`page_id`(urlが欲しいpage_id)を入力してください。
そしたら`url`と`status_code`が返ってきます。