### PR TITLE
ミーティングの議事録をNotionのページに書き込むときに使われるエンドポイントの作成

### DIFF
--- a/dev/backend/api/firebase/func.py
+++ b/dev/backend/api/firebase/func.py
@@ -1,11 +1,12 @@
+import json
 import os
 import sys
-from dotenv import load_dotenv
-import requests
-import json
-from typing import List
 from pprint import pprint
+from typing import List, Optional, Tuple
+
 import firebase_admin
+import requests
+from dotenv import load_dotenv
 from firebase_admin import credentials, firestore
 
 # local
@@ -24,19 +25,25 @@ class FirestoreAPI:
         self,
     ):
         if not firebase_admin._apps:
-            self.cred = credentials.Certificate({
-                "type": os.getenv("FIREBASE_TYPE"),
-                "project_id": os.getenv("FIREBASE_PROJECT_ID"),
-                "private_key_id": os.getenv("FIREBASE_PRIVATE_KEY_ID"),
-                "private_key": os.getenv("FIREBASE_PRIVATE_KEY").replace("\\n", "\n"),
-                "client_email": os.getenv("FIREBASE_CLIENT_EMAIL"),
-                "client_id": os.getenv("FIREBASE_CLIENT_ID"),
-                "auth_uri": os.getenv("FIREBASE_AUTH_URI"),
-                "token_uri": os.getenv("FIREBASE_TOKEN_URI"),
-                "auth_provider_x509_cert_url": os.getenv("FIREBASE_AUTH_PROVIDER_X509_CERT_URL"),
-                "client_x509_cert_url": os.getenv("FIREBASE_CLIENT_X509_CERT_URL"),
-                "universe_domain": os.getenv("FIREBASE_UNIVERSE_DOMAIN")
-            })
+            self.cred = credentials.Certificate(
+                {
+                    "type": os.getenv("FIREBASE_TYPE"),
+                    "project_id": os.getenv("FIREBASE_PROJECT_ID"),
+                    "private_key_id": os.getenv("FIREBASE_PRIVATE_KEY_ID"),
+                    "private_key": os.getenv("FIREBASE_PRIVATE_KEY").replace(
+                        "\\n", "\n"
+                    ),
+                    "client_email": os.getenv("FIREBASE_CLIENT_EMAIL"),
+                    "client_id": os.getenv("FIREBASE_CLIENT_ID"),
+                    "auth_uri": os.getenv("FIREBASE_AUTH_URI"),
+                    "token_uri": os.getenv("FIREBASE_TOKEN_URI"),
+                    "auth_provider_x509_cert_url": os.getenv(
+                        "FIREBASE_AUTH_PROVIDER_X509_CERT_URL"
+                    ),
+                    "client_x509_cert_url": os.getenv("FIREBASE_CLIENT_X509_CERT_URL"),
+                    "universe_domain": os.getenv("FIREBASE_UNIVERSE_DOMAIN"),
+                }
+            )
             self.app = firebase_admin.initialize_app(self.cred)
         else:
             self.app = firebase_admin.get_app()
@@ -45,7 +52,7 @@ class FirestoreAPI:
     def get_notion_api_data(self, user_id: str, project_id: str) -> NotionItem:
         """
         Firestore から Notion API のデータを取得する
-        
+
         Args:
             user_id (str): ユーザーID
             project_id (str): プロジェクトID
@@ -53,13 +60,18 @@ class FirestoreAPI:
         Returns:
             NotionItem: Notion API のデータ
         """
-        
-        query = self.db.collection(user_id).document(project_id)
+
+        query = (
+            self.db.collection("Users")
+            .document(user_id)
+            .collection("Projects")
+            .document(project_id)
+        )
         doc = query.get()
-        
+
         # ここに Firestore からデータを取得する処理を記述
-        
-        if doc.exists: # ドキュメントが存在する場合
+
+        if doc.exists:  # ドキュメントが存在する場合
             data = doc.to_dict()
             notion_api_data = data["notion_api"]
             item = NotionItem(**notion_api_data)
@@ -71,22 +83,48 @@ class FirestoreAPI:
                 duplicated_template_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",  # 複製されたテンプレートのID
             )
             return item
-        
-    def insert_notion_api_data(self, user_id: str, project_id: str, notion_item: NotionItem):
+
+    def insert_notion_api_data(
+        self, user_id: str, project_id: str, notion_item: NotionItem
+    ):
         """
-        Firestore に Notion API のデータを挿入す    
+        Firestore に Notion API のデータを挿入す
         Args:
             user_id (str): ユーザーID
             project_id (str): プロジェクトID
             notion_item (NotionItem): Notion API のデータ
         """
         notion_item = notion_item.dict()
-        
-        data = {
-            "notion_api": notion_item
-        }
+
+        data = {"notion_api": notion_item}
         dic_ref = self.db.collection(user_id).document(project_id)
-        res = dic_ref.set(data) # Firestore にデータを挿入
-        
+        res = dic_ref.set(data)  # Firestore にデータを挿入
+
         return res, 200
-    
+
+    def search_page_id(
+        self, user_id: str, project_id: str, meeting_id
+    ) -> Tuple[Optional[str], bool]:
+        """
+        Firebaseからpage_idを取得するメソッド
+        page_idが無ければ、Noneと返す
+        """
+        query = (
+            self.db.collection("Users")
+            .document(user_id)
+            .collection("Projects")
+            .document(project_id)
+            .collection("Meetings")
+            .document(meeting_id)
+        )
+        doc = query.get()
+
+        if doc.exists:  # ドキュメントが存在する場合
+            data = doc.to_dict()
+            notion_page_id = data["notion_page_id"]
+            is_exists = True
+            return notion_page_id, is_exists
+        else:
+            notion_page_id = None
+            is_exists = False
+            return notion_page_id, is_exists

--- a/dev/backend/api/firebase/func.py
+++ b/dev/backend/api/firebase/func.py
@@ -163,6 +163,14 @@ class FirestoreAPI:
             project_id
         ).collection("Meetings").document(meeting_id).set(data)
 
+    def setup_notion_page_id(
+        self, user_id: str, project_id: str, meeting_id: str, page_id: str
+    ):
+        data = {"notion_page_id": page_id}
+        self.db.collection("Users").document(user_id).collection("Projects").document(
+            project_id
+        ).collection("Meetings").document(meeting_id).set(data)
+
     def get_allproject_id(self, user_id: str):
         return (
             self.db.collection("Users").document(user_id).collection("Projects").get()

--- a/dev/backend/main.py
+++ b/dev/backend/main.py
@@ -1,22 +1,23 @@
-import os
-from dotenv import load_dotenv
-import requests
 import base64
-from fastapi import FastAPI, HTTPException
-from starlette.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from typing import Optional, Union
-import uvicorn
+import os
 from logging import getLogger
+from typing import Optional, Union
+
+import requests
+import uvicorn
+from api.firebase.func import FirestoreAPI
+from api.notion.func import NotionAPI
+from api.notion.schema import *
+from api.schema import *
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from lib.chain import LangchainBot
+from lib.schema import FilePath, TextSplitConfig
 
 # local
 from lib.vectorstore import VectorStore, VectorStoreQdrant
-from lib.chain import LangchainBot
-from lib.schema import FilePath, TextSplitConfig
-from api.schema import *
-from api.notion.schema import *
-from api.notion.func import NotionAPI
-from api.firebase.func import FirestoreAPI
+from pydantic import BaseModel
+from starlette.middleware.cors import CORSMiddleware
 
 load_dotenv()
 app = FastAPI()
@@ -229,7 +230,7 @@ firestore_api = FirestoreAPI()
 
 @app.post("/test/notion/write_db/{user_id}/{project_id}")
 async def test_notion_write_db(
-    minutes_data: MinutesContentsElement, user_id: str, project_id: str
+    minutes_data: MinutesContentsElement, user_id: str, project_id: str, meeting_id: str
 ) -> dict:
     """
     Notionのデータをデータベースに書き込むエンドポイント
@@ -241,8 +242,17 @@ async def test_notion_write_db(
     Returns:
         dict: Notion APIのレスポンス
     """
-    print(minutes_data)
-    # b01ADn1oC6B41T57lqP6
+
+    # テスト用
+    # notion_item = NotionItem(
+    #     access_token="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",  # アクセストークン
+    #     duplicated_template_id="184c5dbe3ed3811dae19c0a9a2b3d5b2",  # 複製されたテンプレートのID
+    # )
+    # notion_page_id = "1843338a59a6814585c0d19b656c2303"
+    notion_block_id = "1853338a-59a6-81b9-b39a-e4c62c1c059f"
+    # is_exists = True
+
+    # firestoreからnotionの認証情報を取得
     notion_item = firestore_api.get_notion_api_data(
         user_id=user_id, project_id=project_id
     )  # project_idを用いてFirestoreからNotionの認証データを取得
@@ -251,18 +261,55 @@ async def test_notion_write_db(
 
     notion_api = NotionAPI(notion_item=notion_item)
 
-    # Notionにデータを送信
-    res, status_code = notion_api.add_database_contents(
-        insert_data=InsertDataSchema(
-            properties_name=MinutesPropertiesNameElement(),  # プロパティ名（固定値）
-            minutes=minutes_data,
-        )
+    # page_idがFirebaseに存在しているかどうか TODO ここでblock_idを取得する
+    notion_page_id, is_exists = firestore_api.search_page_id(
+        user_id, project_id, meeting_id
     )
-    print(
-        "Notion API: ", status_code
-    )  # データが書き込めたかどうかのステータスコードを表示
+    print(notion_page_id)
+    if is_exists:  # page_idが存在する場合
+        # プロパティの上書き
+        res, status = notion_api.overwrite_property(notion_page_id, minutes_data)
+        print("=" * 20)
+        pprint(res)
+        if status != 200:  # エラー
+            return {"message": "Error when overwriting properties", "res": res}, status
 
-    return res
+        # 本文内のblockを全て取得
+        blocks, status = notion_api.get_all_blocks(notion_page_id)
+        if status != 200:  # エラー
+            return {"message": "Error when getting blocks", "blocks": blocks}, status
+
+        # 全てのblockを削除
+        res, status = notion_api.delete_all_blocks(blocks)
+        print("=" * 20)
+        pprint(res)
+        if status != 200:  # エラー
+            return {"message": "Error when overwriting properties", "res": res}, status
+
+        # 本文にblockを追加
+        res, status = notion_api.overwrite_body(notion_block_id, minutes_data)
+        if status != 200:  # エラー
+            return {"message": "Error when overwriting body", "res": res}, status
+        print("=" * 20)
+        pprint(res)
+    else:
+        # Notionに新たなページの作成
+        res, status_code = notion_api.add_database_contents(
+            insert_data=InsertDataSchema(
+                properties_name=MinutesPropertiesNameElement(),  # プロパティ名（固定値）
+                minutes=minutes_data,
+            )
+        )
+        if status != 200:  # エラー
+            return {"message": "Error when creating notion page", "res": res}, status
+        print(
+            "Notion API: ", status_code
+        )  # データが書き込めたかどうかのステータスコードを表示
+        print("notion_page_id", res["id"])  # notionのページを取得
+
+    # TODO firestoreにpage_idとblock_idを保存
+
+    return {"message": "Operation completed"}
 
 
 if __name__ == "__main__":

--- a/dev/backend/main.py
+++ b/dev/backend/main.py
@@ -297,12 +297,11 @@ async def test_notion_write_db(
         print("notion_page_id", res["id"])  # notionのページを取得
 
         # TODO firestoreにpage_idを保存
-        firestore_api.setup_meeting(
+        firestore_api.setup_notion_page_id(
             user_id=user_id,
             project_id=project_id,
             meeting_id=meeting_id,
-            meeting_name=minutes_data.title,
-            meeting_description=minutes_data.summary,
+            page_id=res["id"],
         )
 
     return {"message": "Operation completed"}


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: https://www.notion.so/Notion-184c5dbe3ed380be9aaae3f35c5b0c88

<!-- デザインのURL。なければ次の行を削除してください --

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

GPTが生成したミーティングの議事録をNotionのページに書き込むときに使われるエンドポイントの作成をしました。
処理は以下の通りです。
1. FireStoreにnotion_page_idを取得しに行く。
2. notion_page_idが無ければNotionのページを新たに作成し議事録を書き込み、FireStoreにnotion_page_idを書き込む。
3. notion_page_idがあれば既存のNotionのページに議事録を上書きする。

# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
FireStoreにnotion_page_idを書き込むFirestoreAPIクラスのメソッド(setup_notion_page_id)について、今後同じクラスのメソッドであるsetup_meetingとの結合を検討したいです。
具体的にはFireStoreにnotion_page_idを書き込む際、使用するメソッドをsetup_meetingにし、setup_meetingの引数にnotion_page_idを追加する。setup_meetingの引数であるmeeting_nameとmeeting_descriptionにはMinutesContentsElementスキーマのtitleとsummaryを付与する。
とかですかね。

# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
* [FastAPIのdocsから`/test/notion/write_db/{user_id}/{project_id}`の検証を行った(notion_page_idがある場合と無い場合の両方)]
* [`api/notion/func.py`を実行し、run_test_num=4にしてmarkdownをnotion用のblockに変換する機能の検証] 
# 動作確認方法
エンドポイントを確認したい場合、FastAPIのdocsから`/test/notion/write_db/{user_id}/{project_id}`のParametersを以下に設定し、行ってください。エンドポイントを試す前にnotionページのurlから変更前のページを見ておくと、正しく実行されたか確認することができます。

user_id:test_user
project_id:V3DWPXklyeLJeXOzjzlZ
meeting_id:bbb

notionページのurl:https://www.notion.so/string-1843338a59a681be8221f39f2428ee06?pvs=4

# その他
<!-- レビュアーへのメッセージや一言などあれば -->
