### PR TITLE
プロジェクト・ミーティング画面の内部処理開発

### DIFF
--- a/dev/frontend/react_app/src/App.js
+++ b/dev/frontend/react_app/src/App.js
@@ -16,6 +16,7 @@ import { MicProvider } from './components/MicContext';
 import { DrawerProvider } from './components/DrawerContext';
 import { FastAPIProvider } from './components/FastAPIContext';
 import { UserAuthProvider } from './components/UserAuthContext';
+import { IdListProvider } from './components/IdListContext';
 
 function App() {
   return (
@@ -40,16 +41,18 @@ function App() {
           <DrawerProvider>
             <FastAPIProvider>
               <BrowserRouter>
-                <Routes>
-                  <Route path={`/`} element={<HomePage />} />
-                  <Route path={`/LoginPage`} element={<LoginPage />} />
-                  <Route path={`/SignUpPage`} element={<SignUpPage />} />
-                  <Route path={`/ProjectPage`} element={<ProjectPage />} />
-                  <Route path={`/MeetingPage`} element={<MeetingPage />} />
-                  <Route path={`/DiscussPage`} element={<DiscussPage />} />
-                  <Route path="/auth/notion/callback" element={<NotionCallbackHandler />} />
-                  <Route path="/auth/notion/success" element={<NotionSuccess />} />
-                </Routes>
+                <IdListProvider>
+                  <Routes>
+                    <Route path={`/`} element={<HomePage />} />
+                    <Route path={`/LoginPage`} element={<LoginPage />} />
+                    <Route path={`/SignUpPage`} element={<SignUpPage />} />
+                    <Route path={`/ProjectPage`} element={<ProjectPage />} />
+                    <Route path={`/MeetingPage`} element={<MeetingPage />} />
+                    <Route path={`/DiscussPage`} element={<DiscussPage />} />
+                    <Route path="/auth/notion/callback" element={<NotionCallbackHandler />} />
+                    <Route path="/auth/notion/success" element={<NotionSuccess />} />
+                  </Routes>
+                </IdListProvider>
               </BrowserRouter>
             </FastAPIProvider>
           </DrawerProvider>

--- a/dev/frontend/react_app/src/components/DrawerContext.jsx
+++ b/dev/frontend/react_app/src/components/DrawerContext.jsx
@@ -7,7 +7,6 @@ export const DrawerProvider = ({ children }) => {
     const [ responsecheck, SetResponseCheck ] = useState(false);
     const toggleDrawer = (newOpen) => () => {
         setOpen(newOpen);
-        console.log(chatopen);
     };
     return (
         <DrawerContext.Provider value={{ chatopen, toggleDrawer, responsecheck, SetResponseCheck}}>

--- a/dev/frontend/react_app/src/components/IdListContext.jsx
+++ b/dev/frontend/react_app/src/components/IdListContext.jsx
@@ -1,0 +1,83 @@
+import { useContext, useState, createContext, useEffect } from "react";
+
+const IdListContext = createContext();
+
+export const IdListProvider = ({ children }) => {
+    const [ALLProjectIdList, setALLProjectIdList] = useState([]);
+    const [ALLMeetingIdList, setALLMeetingIdList] = useState([]);
+
+    // setするだけ
+    const SetALLProjectIdList = (new_project) => {
+        setALLProjectIdList(new_project);
+    };
+
+    // setするだけ
+    const SetALLMeetingIdList = (new_meeting) => {
+        setALLMeetingIdList(new_meeting);
+    };
+
+    // ユーザーIDを基に全プロジェクトIDを取得する
+    const GetALLProjectId = async({user_id}) => {
+        console.log("GetALLProjectId:");
+        console.log(user_id);
+        
+        try {
+            const response = await fetch("http://localhost:8080/FB/GetALLProjectId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "user_id": user_id
+                })
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                console.log(data.ALLProjectId);
+                SetALLProjectIdList([data.ALLProjectId]);
+            } else {
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+    // 2つのIDを基に全ミーティングIDを取得する
+    const GetALLMeetingId = async({user_id, project_id}) => {
+        try {
+            const response = await fetch("http://localhost:8080/FB/GetALLMeetingId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "user_id": user_id,
+                    "project_id": project_id
+                })
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                SetALLMeetingIdList(data.ALLMeetingId);
+            } else {
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+
+    return (
+        <IdListContext.Provider value={{ ALLProjectIdList, ALLMeetingIdList, GetALLMeetingId, GetALLProjectId }}>
+            {children}
+        </IdListContext.Provider>
+    );
+};
+
+// Context を利用するカスタムフック
+export const useIdListContext = () => {
+    return useContext(IdListContext);
+};

--- a/dev/frontend/react_app/src/components/IdListContext.jsx
+++ b/dev/frontend/react_app/src/components/IdListContext.jsx
@@ -5,6 +5,8 @@ const IdListContext = createContext();
 export const IdListProvider = ({ children }) => {
     const [ALLProjectIdList, setALLProjectIdList] = useState([]);
     const [ALLMeetingIdList, setALLMeetingIdList] = useState([]);
+    const [CurrentProjectID, setCurrentProjectID] = useState("");
+    const [CurrentMeetingID, setCurrentMeetingID] = useState("");
 
     // setするだけ
     const SetALLProjectIdList = (new_project) => {
@@ -16,9 +18,9 @@ export const IdListProvider = ({ children }) => {
         setALLMeetingIdList(new_meeting);
     };
 
+
     // ユーザーIDを基に全プロジェクトIDを取得する
     const GetALLProjectId = async({user_id}) => {
-        console.log("GetALLProjectId:");
         console.log(user_id);
         
         try {
@@ -34,7 +36,6 @@ export const IdListProvider = ({ children }) => {
 
             if (response.ok) {
                 const data = await response.json();
-                console.log(data.ALLProjectId);
                 SetALLProjectIdList([data.ALLProjectId]);
             } else {
                 throw new Error(`Error: ${response.status}`);
@@ -71,7 +72,7 @@ export const IdListProvider = ({ children }) => {
 
 
     return (
-        <IdListContext.Provider value={{ ALLProjectIdList, ALLMeetingIdList, GetALLMeetingId, GetALLProjectId }}>
+        <IdListContext.Provider value={{ ALLProjectIdList, ALLMeetingIdList, GetALLMeetingId, GetALLProjectId, CurrentProjectID, setCurrentProjectID, CurrentMeetingID, setCurrentMeetingID }}>
             {children}
         </IdListContext.Provider>
     );

--- a/dev/frontend/react_app/src/components/LoginForm.jsx
+++ b/dev/frontend/react_app/src/components/LoginForm.jsx
@@ -23,24 +23,13 @@ export default function LoginForm() {
             await setPersistence(auth, inMemoryPersistence);
             await signInWithEmailAndPassword(auth, UserEmail, PassWord);
             SetUserID(auth.currentUser.uid);
-            alert("Login successful!"); // 成功時の通知
+            // alert("Login successful!"); // 成功時の通知
             GotoProjectPage();
         } catch (error) {
             console.error("Error during sign-up:", error);
             alert(error.message); // エラー時の通知
         }
     };
-
-    // UserID が更新されたときに実行
-    useEffect(() => {
-        if (UserID) {
-            console.log("Updated UserID:", UserID);
-        }
-        else {
-            console.log("empty useid!");
-        };
-        
-    }, [UserID]);
 
     return (
         <div className="Login_container">

--- a/dev/frontend/react_app/src/components/LoginForm.jsx
+++ b/dev/frontend/react_app/src/components/LoginForm.jsx
@@ -20,7 +20,7 @@ export default function LoginForm() {
     const Clicklogin = async () => {
         try {
             // Firebase Authentication を使ってサインアップ
-            await setPersistence(auth, browserSessionPersistence);
+            await setPersistence(auth, inMemoryPersistence);
             await signInWithEmailAndPassword(auth, UserEmail, PassWord);
             SetUserID(auth.currentUser.uid);
             alert("Login successful!"); // 成功時の通知

--- a/dev/frontend/react_app/src/components/Meeting.jsx
+++ b/dev/frontend/react_app/src/components/Meeting.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import "./MeetingList.css";
+import { useIdListContext } from "./IdListContext";
+import { useUserAuthContext } from "./UserAuthContext";
 
-export default function MeetingList() {
+export default function Meeting({meeting_id}) {
 
     const Times = {
         day: '2024//03/09',
@@ -13,13 +15,53 @@ export default function MeetingList() {
     const togglePlayPause = () => {
         setIsPlaying(!isPlaying);
     };
+    const [MeetingName, setMeetingName] = useState("");
+    const [MeetingDescription, setMeetingDescription] = useState("");
+    const { CurrentProjectID } = useIdListContext();
+    const {UserID} = useUserAuthContext();
+
+    // プロジェクト情報を取得する関数
+    const GetMeetingInfoFromId = async () => {
+        try {
+            const response = await fetch("http://localhost:8080/FB/GetMeetingInfoFromId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "user_id": UserID,
+                    "project_id": CurrentProjectID,
+                    "meeting_id": meeting_id
+                }),
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                setMeetingName(data.meeting_name);
+                setMeetingDescription(data.meeting_description);
+            } else {
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+
+    // コンポーネントの初回レンダリング時にGetProjectInfoFromIdを実行
+    useEffect(() => {
+        if (meeting_id && UserID) {
+            console.log("update meeting info");
+            GetMeetingInfoFromId();
+        }
+    }, [CurrentProjectID, UserID]); // project_id または UserID が変更されたときにも再実行
 
     return (
         <div className="MeetingList_container">
             <div className="Meeting_content">
                 <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
+                    <h5 className="Meeting_date">{MeetingName}</h5>
+                    <p className="Meeting_time">{MeetingDescription}</p>
                 </div>
                 <div className="Meeting_buttons">
                     <button onClick={togglePlayPause}>

--- a/dev/frontend/react_app/src/components/Meeting.jsx
+++ b/dev/frontend/react_app/src/components/Meeting.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./MeetingList.css";
+
+export default function MeetingList() {
+
+    const Times = {
+        day: '2024//03/09',
+        time: '11:30~12:00'
+    };
+
+    const [isPlaying, setIsPlaying] = useState(false);
+    const togglePlayPause = () => {
+        setIsPlaying(!isPlaying);
+    };
+
+    return (
+        <div className="MeetingList_container">
+            <div className="Meeting_content">
+                <div className="Meeting_days">
+                    <h5 className="Meeting_date">{Times.day}</h5>
+                    <p className="Meeting_time">{Times.time}</p>
+                </div>
+                <div className="Meeting_buttons">
+                    <button onClick={togglePlayPause}>
+                        <img 
+                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
+                            alt="Play/Pause Icon" 
+                            height="40" 
+                        />
+                        <p>{isPlaying ? "Pause" : "Play"}</p>
+                    </button>
+                    <button>
+                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
+                        <p>議事録</p>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/dev/frontend/react_app/src/components/MeetingCreate.jsx
+++ b/dev/frontend/react_app/src/components/MeetingCreate.jsx
@@ -1,6 +1,8 @@
-import React from "react";
+import { React, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./MeetingCreate.css";
+import MeetingPopup from "./MeetingPopup";
+
 
 
 
@@ -10,11 +12,29 @@ export default function MeetingCreate() {
     const GotoDiscussPage = () => {
         navigate("/DiscussPage")
     }
+    const [isPopupVisible, setPopupVisible] = useState(false);
+    const togglePopup = () => {
+        setPopupVisible(!isPopupVisible);
+    };
 
     return (
         <div className="MeetingCreate_container">
+
             <button className="Pen_button"><img src="./images/pen.svg" alt="" /></button>
-            <button className="MeetingCreate_button" onClick={GotoDiscussPage}>会議室を作成</button>
-        </div>
+            {/* <button onClick={update}>更新</button> */}
+
+            {/* ポップアップ */}
+            {isPopupVisible && (
+                <div className="popup_overlay" onClick={togglePopup}>
+                    <div className="popup_content" onClick={(e) => e.stopPropagation()}>
+                        <button className="close_button" onClick={togglePopup}>
+                            ✕
+                        </button>
+                        <MeetingPopup />
+                    </div>
+                </div>
+            )}
+            <button className="MeetingCreate_button" onClick={togglePopup}>会議室を作成</button>
+        </div >
     );
 }

--- a/dev/frontend/react_app/src/components/MeetingDetails.jsx
+++ b/dev/frontend/react_app/src/components/MeetingDetails.jsx
@@ -1,21 +1,52 @@
-import React from "react";
+import { React, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import "./MeetingDetails.css";
+import { useUserAuthContext } from "./UserAuthContext";
+import { useIdListContext } from "./IdListContext";
 
-const Meeting = {
-    title: 'ミーティングのタイトル',
-    details: 'この会議ではAIに関する新たなソリューション開発を行います。会議は○○室で行い、全力で取り組むものとする。'
-};
 
 
 export default function MeetingDetails() {
+    const [ProjectName, setProjectName] = useState("");
+    const [ProjectDescription, setProjectDescription] = useState("");
 
-   
-    
+    const { UserID } = useUserAuthContext();
+    const { CurrentProjectID } = useIdListContext();
+
+    // プロジェクト情報を取得する関数
+    const GetProjectInfoFromId = async () => {
+        try {
+            const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "user_id": UserID,
+                    "project_id": CurrentProjectID,
+                }),
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                setProjectName(data.project_name);
+                setProjectDescription(data.project_description);
+            } else {
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+    useEffect(()=>{
+        GetProjectInfoFromId();
+    }, []);
+
     return (
         <div className="MeetingDetails_container">
-            <h1 className="Meeting_title">{Meeting.title}</h1>
-            <p className="Meeting_details">{Meeting.details}</p>
+            <h1 className="Meeting_title">{ProjectName}</h1>
+            <p className="Meeting_details">{ProjectDescription}</p>
         </div>
     );
 }

--- a/dev/frontend/react_app/src/components/MeetingList.jsx
+++ b/dev/frontend/react_app/src/components/MeetingList.jsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import "./MeetingList.css";
+import Meeting from "./Meeting";
+import { useIdListContext } from "./IdListContext";
+import { useUserAuthContext } from "./UserAuthContext";
 
 export default function MeetingList() {
 
@@ -9,123 +12,22 @@ export default function MeetingList() {
         time: '11:30~12:00'
     };
 
-    const [isPlaying, setIsPlaying] = useState(false);
-    const togglePlayPause = () => {
-        setIsPlaying(!isPlaying);
+    const { ALLMeetingIdList, GetALLMeetingId, CurrentProjectID } = useIdListContext();
+    const { UserID } = useUserAuthContext();
+
+    const update = () => {
+        GetALLMeetingId({user_id: UserID, project_id: CurrentProjectID});
     };
+    useEffect(() => {
+        update();
+        console.log("get all meeting id");
+    }, []);
 
     return (
-        <div className="MeetingList_container">
-
-            <div className="Meeting_content">
-                <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
-                </div>
-                <div className="Meeting_buttons">
-                    <button onClick={togglePlayPause}>
-                        <img 
-                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
-                            alt="Play/Pause Icon" 
-                            height="40" 
-                        />
-                        <p>{isPlaying ? "Pause" : "Play"}</p>
-                    </button>
-                    <button>
-                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
-                        <p>議事録</p>
-                    </button>
-                </div>
-            </div>
-
-            <div className="Meeting_content">
-                <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
-                </div>
-                <div className="Meeting_buttons">
-                    <button onClick={togglePlayPause}>
-                        <img 
-                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
-                            alt="Play/Pause Icon" 
-                            height="40" 
-                        />
-                        <p>{isPlaying ? "Pause" : "Play"}</p>
-                    </button>
-                    <button>
-                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
-                        <p>議事録</p>
-                    </button>
-                </div>
-            </div>
-
-
-            <div className="Meeting_content">
-                <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
-                </div>
-                <div className="Meeting_buttons">
-                    <button onClick={togglePlayPause}>
-                        <img 
-                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
-                            alt="Play/Pause Icon" 
-                            height="40" 
-                        />
-                        <p>{isPlaying ? "Pause" : "Play"}</p>
-                    </button>
-                    <button>
-                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
-                        <p>議事録</p>
-                    </button>
-                </div>
-            </div>
-
-
-
-            <div className="Meeting_content">
-                <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
-                </div>
-                <div className="Meeting_buttons">
-                    <button onClick={togglePlayPause}>
-                        <img 
-                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
-                            alt="Play/Pause Icon" 
-                            height="40" 
-                        />
-                        <p>{isPlaying ? "Pause" : "Play"}</p>
-                    </button>
-                    <button>
-                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
-                        <p>議事録</p>
-                    </button>
-                </div>
-            </div>
-
-
-            <div className="Meeting_content">
-                <div className="Meeting_days">
-                    <h5 className="Meeting_date">{Times.day}</h5>
-                    <p className="Meeting_time">{Times.time}</p>
-                </div>
-                <div className="Meeting_buttons">
-                    <button onClick={togglePlayPause}>
-                        <img 
-                            src={isPlaying ? "/images/Pause.svg" : "/images/Play.svg"} 
-                            alt="Play/Pause Icon" 
-                            height="40" 
-                        />
-                        <p>{isPlaying ? "Pause" : "Play"}</p>
-                    </button>
-                    <button>
-                        <img src="/images/minutes.svg" alt="DiscussPlanner Logo" height="40" />
-                        <p>議事録</p>
-                    </button>
-                </div>
-            </div>
-
+        <div>
+            {ALLMeetingIdList.flat().map((meeting_id) => (
+                            <Meeting meeting_id={meeting_id} />
+            ))}
         </div>
     );
 }

--- a/dev/frontend/react_app/src/components/MeetingPopup.jsx
+++ b/dev/frontend/react_app/src/components/MeetingPopup.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./ProjectCreate.css"; // CSSファイルをインポート
+import { useIdListContext } from "./IdListContext";
+import { useUserAuthContext } from "./UserAuthContext";
+
+
+export default function MeetingPopup() {
+    const navigate = useNavigate();
+    const {UserID} = useUserAuthContext();
+    const [MeetingName, setMeetingName] = useState("");
+    const [MeetingDescription, setMeetingDescription] = useState("");
+    const [MeetingTime, setMeetingTime] = useState("");
+    const { GetALLMeetingId, CurrentProjectID, setCurrentProjectID, CurrentMeetingID, setCurrentMeetingID } = useIdListContext();
+
+    const ClickedCreateProject = async() => {
+        const { v4: uuidv4 } = require('uuid');
+        const meeting_id = uuidv4();
+        try {
+            const response = await fetch("http://localhost:8080/FB/WriteMeetingId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                        "user_id": UserID,
+                        "project_id": CurrentProjectID,
+                        "meeting_id": meeting_id,
+                        "meeting_name": MeetingName,
+                        "meeting_description": MeetingDescription
+                }),
+            });
+
+            if (response.ok) {
+                // alert("Success create meeting");
+                setCurrentMeetingID(meeting_id);
+                GetALLMeetingId({user_id: UserID, project_id: CurrentProjectID});
+                navigate("/DiscussPage");
+            } else {
+                alert("Fail create project");
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+    
+
+    return (
+        <div className="Create_container">
+            <div className="Create_title">
+                <input type="text" placeholder="会議のタイトルを入力してください" value={MeetingName} onChange={(e) => setMeetingName(e.target.value)}/>
+            </div>
+            <div className="Create_content">
+                <div>
+                    <div className="Create_details">
+                        <textarea placeholder="会議目標と内容を入力してください" className="input-textarea" value={MeetingDescription} onChange={(e) => setMeetingDescription(e.target.value)}/>
+                    </div>
+                    <div className="Create_time">
+                        <textarea placeholder="会議の時間" className="input-textarea" value={MeetingTime} onChange={(e) => setMeetingTime(e.target.value)}/>
+                    </div>
+                    <div>
+                        <button className="create-button" onClick={ClickedCreateProject}>会議を開く</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/dev/frontend/react_app/src/components/Project.jsx
+++ b/dev/frontend/react_app/src/components/Project.jsx
@@ -1,33 +1,68 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./Project.css";
+import { useUserAuthContext } from "./UserAuthContext";
 
-export default function Project() {
+export default function Project({ project_id }) {
     const navigate = useNavigate();
+
+    const { UserID } = useUserAuthContext();
+    const [ProjectName, setProjectName] = useState("");
+    const [ProjectDescription, setProjectDescription] = useState("");
+
     const GotoMeetingPage = () => {
-        navigate("/MeetingPage")
+        navigate("/MeetingPage");
     }
+
+    // プロジェクト情報を取得する関数
+    const GetProjectInfoFromId = async () => {
+        try {
+            const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "user_id": UserID,
+                    "project_id": project_id,
+                }),
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                setProjectName(data.project_name);
+                setProjectDescription(data.project_description);
+                console.log("Project Info:", { ProjectName, ProjectDescription });
+            } else {
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
+
+    // コンポーネントの初回レンダリング時にGetProjectInfoFromIdを実行
+    useEffect(() => {
+        if (project_id && UserID) {
+            console.log("update project info");
+            GetProjectInfoFromId();
+        }
+    }, [project_id, UserID]); // project_id または UserID が変更されたときにも再実行
+
     return (
         <div className="Project_container">
             <div className="card">
-                <h3 className="card_title">プロジェクトタイトル</h3>
+                <h3 className="card_title">{ProjectName}</h3>
                 <div className="card_content">
-                    <p>
-                        プロジェクトの説明
-                    </p>
-                    <p>
-                        この会議では、AIに関する新たなソリューション開発を行います。
-                    </p>
+                    <p>{ProjectDescription}</p>
                 </div>
-
                 <div className="card_under">
                     <div className="button_group">
                         <button className="primary_button" onClick={GotoMeetingPage} >
-                            会議を開始する
+                            開く
                         </button>
-                        <button className="secondary_button">
-                            Details
-                        </button>
+                        <button className="secondary_button">Option</button>
                     </div>
                     <div className="icon_container">
                         <div className="icon">1</div>

--- a/dev/frontend/react_app/src/components/Project.jsx
+++ b/dev/frontend/react_app/src/components/Project.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./Project.css";
 import { useUserAuthContext } from "./UserAuthContext";
+import { useIdListContext } from "./IdListContext";
 
 export default function Project({ project_id }) {
     const navigate = useNavigate();
@@ -9,9 +10,16 @@ export default function Project({ project_id }) {
     const { UserID } = useUserAuthContext();
     const [ProjectName, setProjectName] = useState("");
     const [ProjectDescription, setProjectDescription] = useState("");
+    const {setCurrentProjectID} = useIdListContext();
 
     const GotoMeetingPage = () => {
-        navigate("/MeetingPage");
+        setCurrentProjectID(project_id);
+        navigate("/MeetingPage", {
+            state: {
+                projectName: ProjectName,
+                projectDescription: ProjectDescription,
+            },
+        });
     }
 
     // プロジェクト情報を取得する関数

--- a/dev/frontend/react_app/src/components/ProjectCreate.jsx
+++ b/dev/frontend/react_app/src/components/ProjectCreate.jsx
@@ -33,7 +33,7 @@ export default function ProjectCreate() {
     const [ProjectName, setProjectName] = useState("");
     const [ProjectDescription, setProjectDescription] = useState("");
     const [AIsRole, setAIsRole] = useState("");
-    const { GetALLProjectId } = useIdListContext();
+    const { GetALLProjectId, setCurrentProjectID } = useIdListContext();
 
     const ClickedCreateProject = async() => {
         const { v4: uuidv4 } = require('uuid');

--- a/dev/frontend/react_app/src/components/ProjectCreate.jsx
+++ b/dev/frontend/react_app/src/components/ProjectCreate.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./ProjectCreate.css"; // CSSファイルをインポート
+import { useIdListContext } from "./IdListContext";
+import { useUserAuthContext } from "./UserAuthContext";
+
 
 export default function ProjectCreate() {
     const navigate = useNavigate();
@@ -26,20 +29,55 @@ export default function ProjectCreate() {
         setPercentage4(e.target.value);
     };
 
+    const {UserID} = useUserAuthContext();
+    const [ProjectName, setProjectName] = useState("");
+    const [ProjectDescription, setProjectDescription] = useState("");
+    const [AIsRole, setAIsRole] = useState("");
+    const { GetALLProjectId } = useIdListContext();
+
+    const ClickedCreateProject = async() => {
+        const { v4: uuidv4 } = require('uuid');
+        const project_id = uuidv4();
+        try {
+            const response = await fetch("http://localhost:8080/FB/WriteProjectId", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                        "user_id": UserID,
+                        "project_id": project_id,
+                        "project_name": ProjectName,
+                        "project_description": ProjectDescription
+                }),
+            });
+
+            if (response.ok) {
+                alert("Success create project");
+                GetALLProjectId({user_id: UserID});
+            } else {
+                alert("Fail create project");
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+    };
+
     
 
     return (
         <div className="Create_container">
             <div className="Create_title">
-                <input type="text" placeholder="会議のタイトルを入力してください" />
+                <input type="text" placeholder="プロジェクトのタイトルを入力してください" value={ProjectName} onChange={(e) => setProjectName(e.target.value)}/>
             </div>
             <div className="Create_content">
                 <div>
                     <div className="Create_details">
-                        <textarea placeholder="会議の内容を入力してください" className="input-textarea" />
+                        <textarea placeholder="プロジェクトの内容を入力してください" className="input-textarea" value={ProjectDescription} onChange={(e) => setProjectDescription(e.target.value)}/>
                     </div>
                     <div className="Create_AI">
-                        <textarea placeholder="AIの役割を入力してください" className="input-textarea" />
+                        <textarea placeholder="AIの役割を入力してください" className="input-textarea" value={AIsRole} onChange={(e) => setAIsRole(e.target.value)}/>
                     </div>
                 </div>
                 <div className="Create_parameters">
@@ -53,7 +91,7 @@ export default function ProjectCreate() {
                             value={percentage1}
                             onChange={handleChange1}
                         />
-                        <p>template</p>
+                        <p>AIの性格</p>
                         <input
                             type="range"
                             min="0"
@@ -61,7 +99,7 @@ export default function ProjectCreate() {
                             value={percentage2}
                             onChange={handleChange2}
                         />
-                        <p>template</p>
+                        <p>AIの声の高さ</p>
                         <input
                             type="range"
                             min="0"
@@ -69,7 +107,7 @@ export default function ProjectCreate() {
                             value={percentage3}
                             onChange={handleChange3}
                         />
-                        <p>template</p>
+                        <p>AIが話す速度</p>
                         <input
                             type="range"
                             min="0"
@@ -79,7 +117,7 @@ export default function ProjectCreate() {
                         />
                     </div>
                     <div>
-                        <button className="create-button" onClick={GotoMeetingPage}>会議室を作成</button>
+                        <button className="create-button" onClick={ClickedCreateProject}>プロジェクトを作成</button>
                     </div>
                 </div>
             </div>

--- a/dev/frontend/react_app/src/components/ProjectList.jsx
+++ b/dev/frontend/react_app/src/components/ProjectList.jsx
@@ -19,10 +19,10 @@ export default function ProjectList() {
         GetALLProjectId({user_id: UserID});
     }
 
-    // useEffect(() => {
-    //     console.log("RUN UPDATE");
-    //     update();
-    // }, [ALLProjectIdList]);
+    useEffect(() => {
+        console.log("RUN UPDATE");
+        update();
+    }, []);
 
     return (
         <div>
@@ -33,7 +33,7 @@ export default function ProjectList() {
 
             {/* ポップアップを表示するボタン */}
             <button className="Create_button" onClick={togglePopup}>新しいプロジェクトを作成</button>
-            <button onClick={update}>更新</button>
+            {/* <button onClick={update}>更新</button> */}
 
             {/* ポップアップ */}
             {isPopupVisible && (

--- a/dev/frontend/react_app/src/components/ProjectList.jsx
+++ b/dev/frontend/react_app/src/components/ProjectList.jsx
@@ -1,26 +1,39 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Project from "../components/Project";
 import ProjectCreate from "../components/ProjectCreate";
 import "./ProjectList.css";
+import { useIdListContext } from "./IdListContext";
+import { useUserAuthContext } from "./UserAuthContext";
+
 
 export default function ProjectList() {
     const [isPopupVisible, setPopupVisible] = useState(false);
-
     const togglePopup = () => {
         setPopupVisible(!isPopupVisible);
     };
+    const {UserID} = useUserAuthContext();
+
+    const { ALLProjectIdList, GetALLProjectId } = useIdListContext();
+
+    const update = () => {
+        GetALLProjectId({user_id: UserID});
+    }
+
+    // useEffect(() => {
+    //     console.log("RUN UPDATE");
+    //     update();
+    // }, [ALLProjectIdList]);
 
     return (
         <div>
             {/* プロジェクトリスト */}
-            <Project />
-            <Project />
-            <Project />
-            <Project />
-            <Project />
+            {ALLProjectIdList.flat().map((project_id) => (
+                <Project project_id={project_id} />
+            ))}
 
             {/* ポップアップを表示するボタン */}
             <button className="Create_button" onClick={togglePopup}>新しいプロジェクトを作成</button>
+            <button onClick={update}>更新</button>
 
             {/* ポップアップ */}
             {isPopupVisible && (

--- a/dev/frontend/react_app/src/components/UserAuthContext.jsx
+++ b/dev/frontend/react_app/src/components/UserAuthContext.jsx
@@ -8,8 +8,8 @@ export const UserAuthProvider = ({ children }) => {
     const [UserEmail, setUserEmail] = useState('');
     const [PassWord, setPassWord] = useState('');
     const [UserID, setUserID] = useState('');
-    const SetUserID = async(id) => {
-        await setUserID(id);
+    const SetUserID = (id) => {
+        setUserID(id);
     };
     
     const [CurrentUser, setCurrentUser] = useState(null);

--- a/dev/frontend/react_app/src/pages/MeetingPage.jsx
+++ b/dev/frontend/react_app/src/pages/MeetingPage.jsx
@@ -11,7 +11,7 @@ const MeetingPage = () => {
             <MainAppBar></MainAppBar>
             <div style={{ display: "flex" }}>
                 <div>
-                    <MeetingDetails></MeetingDetails>
+                    <MeetingDetails ></MeetingDetails>
                     <MeetingList></MeetingList>
                 </div>
                 <div>


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion:
[プロジェクトタスク](https://www.notion.so/Q1-14cc5dbe3ed380d4a411d7964f8fdd45?p=feffca12912e434794a78a5db1b8d54d&pm=s)
[ミーティングタスク](https://www.notion.so/Q1-14cc5dbe3ed380d4a411d7964f8fdd45?p=f9ae3c362e3d4b3bb690bb5b4ed8d1b1&pm=s)


<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
大きく変更したのは、プロジェクト一覧画面、プロジェクト作成ポップアップ、ミーティング一覧画面、ミーティング作成ポップアップです。主に、見た目ではなく内部処理を開発した。



# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- 「プロジェクト一覧画面」：各ユーザーが所持しているプロジェクトを一括表示できるように変更
- 「プロジェクト作成ポップアップ」：新規作成に必要な情報を入力後、"作成ボタン"クリックで「プロジェクト一覧画面」に追加するプロジェクトカードを作成できるように変更
- 「ミーティング一覧画面」：各ユーザーが所持している全ミーティング情報を各プロジェクトごとに、一括表示できるように変更
- 「ミーティング作成ポップアップ」：新規作成に必要な情報を入力後、"作成ボタン"クリックで「ミーティング一覧画面」に追加するミーティングカードを作成できるように変更。また、作成後にAIとのディスカッションができるページへ遷移するように変更。



# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
「cssのファイル名を汎用的なものに変更する。それに合わせてファイル構成等の変更も行いたい」
今回の変更では、css等のファイルにはほとんど触れていないため、既存のcssを流用している。そのため、プロジェクト名の値を時間表示用のcssで表示するなどの事態が発生している。ファイル構成にも難があり、ページとコンポーネントの繋がりが見えないことから、今後重大なバグが発生する可能性も考えられる。これらのことから、ファイル名とファイルおよびフォルダ構成の整備を検討したい。

ほかには、現状、F5連打に弱いため対策を検討する必要がある。


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
* [Dockerでフロントエンド側の操作から上記記載"細かな変更点"をテスト]
* 行った確認フローは、下記動作確認方法を参照


# 動作確認方法
動作確認お願いします。以下のフローを3回繰り返してください。
1. ユーザーログイン
2. 右下のボタンからプロジェクト作成（2回目はスキップ）
3. プロジェクト一覧が表示される
4. 各プロジェクトカードの"開く"をクリック
5. ミーティング一覧画面が表示される
6. 上部にプロジェクト名と説明が記載されているか確認
7. 右下のボタンから会議室を作成
8. ディスカッションページに遷移される
9. 念のためマイクの入力を確認
10. 左上のDiscussPlannerのアイコンをクリック
11. 最初のページに戻ったことを確認後、F5でページの更新


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
不明点・アドバイス等、気楽にコメントください！よろしくおねがいします！！！
