### PR TITLE
フロント側からアイデアの一覧を送受信できるようにする

### DIFF
--- a/dev/backend/api/firebase/func.py
+++ b/dev/backend/api/firebase/func.py
@@ -95,8 +95,8 @@ class FirestoreAPI:
         data = {"user_type":"User"}
         self.db.collection("Users").document(user_id).set(data)
 
-    def setup_project(self, user_id:str, project_id: str, project_name: str, project_description: str):
-        data = {"project_name":project_name, "project_description":project_description}
+    def setup_project(self, user_id:str, project_id: str, project_name: str, project_description: str, ai_role: str):
+        data = {"project_name":project_name, "project_description":project_description, "ais_role": ai_role}
         self.db.collection("Users").document(user_id).collection("Projects").document(project_id).set(data)
 
     def setup_meeting(self, user_id: str, project_id: str, meeting_id: str, meeting_name: str, meeting_description: str):

--- a/dev/backend/api/schema.py
+++ b/dev/backend/api/schema.py
@@ -231,6 +231,7 @@ class ProjectItem(BaseModel):
     project_id: str
     project_name: str
     project_description: str
+    ai_role: str
 
 
 class MeetingItem(BaseModel):

--- a/dev/backend/main.py
+++ b/dev/backend/main.py
@@ -291,12 +291,14 @@ async def FBWriteProjectId(project_item: ProjectItem):
     project_id = project_item.project_id
     project_name = project_item.project_name
     project_description = project_item.project_description
+    ai_role = project_item.ai_role
     if project_id:
         firestore_api.setup_project(
             user_id=user_id,
             project_id=project_id,
             project_name=project_name,
             project_description=project_description,
+            ai_role=ai_role
         )
 
 

--- a/dev/frontend/react_app/src/App.js
+++ b/dev/frontend/react_app/src/App.js
@@ -17,6 +17,7 @@ import { DrawerProvider } from './components/DrawerContext';
 import { FastAPIProvider } from './components/FastAPIContext';
 import { UserAuthProvider } from './components/UserAuthContext';
 import { IdListProvider } from './components/IdListContext';
+import { ChatPropatiesProvider } from './components/ChatPropatiesContext';
 
 function App() {
   return (
@@ -42,16 +43,18 @@ function App() {
             <FastAPIProvider>
               <BrowserRouter>
                 <IdListProvider>
-                  <Routes>
-                    <Route path={`/`} element={<HomePage />} />
-                    <Route path={`/LoginPage`} element={<LoginPage />} />
-                    <Route path={`/SignUpPage`} element={<SignUpPage />} />
-                    <Route path={`/ProjectPage`} element={<ProjectPage />} />
-                    <Route path={`/MeetingPage`} element={<MeetingPage />} />
-                    <Route path={`/DiscussPage`} element={<DiscussPage />} />
-                    <Route path="/auth/notion/callback" element={<NotionCallbackHandler />} />
-                    <Route path="/auth/notion/success" element={<NotionSuccess />} />
-                  </Routes>
+                  <ChatPropatiesProvider>
+                    <Routes>
+                      <Route path={`/`} element={<HomePage />} />
+                      <Route path={`/LoginPage`} element={<LoginPage />} />
+                      <Route path={`/SignUpPage`} element={<SignUpPage />} />
+                      <Route path={`/ProjectPage`} element={<ProjectPage />} />
+                      <Route path={`/MeetingPage`} element={<MeetingPage />} />
+                      <Route path={`/DiscussPage`} element={<DiscussPage />} />
+                      <Route path="/auth/notion/callback" element={<NotionCallbackHandler />} />
+                      <Route path="/auth/notion/success" element={<NotionSuccess />} />
+                    </Routes>
+                  </ChatPropatiesProvider>
                 </IdListProvider>
               </BrowserRouter>
             </FastAPIProvider>

--- a/dev/frontend/react_app/src/components/AIAgentsImage.jsx
+++ b/dev/frontend/react_app/src/components/AIAgentsImage.jsx
@@ -48,8 +48,8 @@ export default function AIAgentsImage() {
     const UseFastAPITosendUserMessage = async (message) => {
         try {
 
-            // const response = await fetch(`https://${currentHost}/api/chat/111`, {
-            const response = await fetch(`http://${currentHost}:8080/chat/111`, {
+            const response = await fetch(`https://${currentHost}/api/chat/111`, {
+            // const response = await fetch(`http://${currentHost}:8080/chat/111`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -161,11 +161,11 @@ export default function AIAgentsImage() {
             if (!faceclicked) {
                 // 3秒間何も発言がなければ実行
                 timerRef.current = setTimeout(() => {
-                    console.log("3秒間発言がなかったので確定:", transcript);
+                    console.log("議事録を送信:", transcript);
                     setFinalTranscript(transcript); // 確定した文章を保存
                     UseFastAPITosendMinutes(finalTranscript);
                     resetTranscript(); // transcriptをリセット
-                }, 2000); // 3秒
+                }, 2000); // 2秒
             };
         }
     }, [transcript, resetTranscript]);

--- a/dev/frontend/react_app/src/components/ChatPropatiesContext.jsx
+++ b/dev/frontend/react_app/src/components/ChatPropatiesContext.jsx
@@ -1,0 +1,35 @@
+import { useContext, useState, createContext, useEffect } from "react";
+
+const ChatPropatiesContext = createContext();
+
+export const ChatPropatiesProvider = ({ children }) => {
+    
+    const [project_name, set_project_name] = useState("");
+    const [project_description, set_project_description] = useState("");
+    const [meeting_name, set_meeting_name] = useState("");
+    const [meeting_description, set_meeting_description] = useState("");
+    const [ai_role, set_ai_role] = useState("");
+    const [maximum_time, set_maximum_time] = useState("");
+    const [OnBoardIdea, setIdeaOnBoard] = useState([]);
+    const [GotIdea, setGotIdea] = useState([]);
+
+    const SetIdeaOnBoard_ADD = (doc) => {
+        setIdeaOnBoard(prevdoc => [...prevdoc, doc]);
+    };
+    
+    const SetGotIdea = (doc) => {
+        setGotIdea([doc]);
+    };
+
+    return (
+        <ChatPropatiesContext.Provider value={{ project_name, set_project_name, project_description, set_project_description, meeting_name, set_meeting_name, meeting_description, set_meeting_description, ai_role, set_ai_role, maximum_time, set_maximum_time, OnBoardIdea, setIdeaOnBoard, GotIdea, SetIdeaOnBoard_ADD, SetGotIdea }}>
+            {children}
+        </ChatPropatiesContext.Provider >
+    );
+};
+
+// Context を利用するカスタムフック
+export const useChatPropatiesContext = () => {
+    return useContext(ChatPropatiesContext);
+};
+

--- a/dev/frontend/react_app/src/components/Meeting.jsx
+++ b/dev/frontend/react_app/src/components/Meeting.jsx
@@ -19,6 +19,7 @@ export default function Meeting({meeting_id}) {
     const [MeetingDescription, setMeetingDescription] = useState("");
     const { CurrentProjectID } = useIdListContext();
     const {UserID} = useUserAuthContext();
+    
 
     // プロジェクト情報を取得する関数
     const GetMeetingInfoFromId = async () => {

--- a/dev/frontend/react_app/src/components/MeetingCreate.jsx
+++ b/dev/frontend/react_app/src/components/MeetingCreate.jsx
@@ -5,7 +5,6 @@ import MeetingPopup from "./MeetingPopup";
 
 
 
-
 export default function MeetingCreate() {
 
     const navigate = useNavigate();

--- a/dev/frontend/react_app/src/components/MeetingPopup.jsx
+++ b/dev/frontend/react_app/src/components/MeetingPopup.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import "./ProjectCreate.css"; // CSSファイルをインポート
 import { useIdListContext } from "./IdListContext";
 import { useUserAuthContext } from "./UserAuthContext";
+import { useChatPropatiesContext } from "./ChatPropatiesContext";
 
 
 export default function MeetingPopup() {
@@ -12,6 +13,7 @@ export default function MeetingPopup() {
     const [MeetingDescription, setMeetingDescription] = useState("");
     const [MeetingTime, setMeetingTime] = useState("");
     const { GetALLMeetingId, CurrentProjectID, setCurrentProjectID, CurrentMeetingID, setCurrentMeetingID } = useIdListContext();
+    const { set_meeting_name, set_meeting_description, set_maximum_time } = useChatPropatiesContext();
 
     const ClickedCreateProject = async() => {
         const { v4: uuidv4 } = require('uuid');
@@ -34,7 +36,10 @@ export default function MeetingPopup() {
             if (response.ok) {
                 // alert("Success create meeting");
                 setCurrentMeetingID(meeting_id);
+                set_meeting_name(MeetingName);
+                set_meeting_description(MeetingDescription);
                 GetALLMeetingId({user_id: UserID, project_id: CurrentProjectID});
+                set_maximum_time(MeetingTime);
                 navigate("/DiscussPage");
             } else {
                 alert("Fail create project");

--- a/dev/frontend/react_app/src/components/Project.jsx
+++ b/dev/frontend/react_app/src/components/Project.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import "./Project.css";
 import { useUserAuthContext } from "./UserAuthContext";
 import { useIdListContext } from "./IdListContext";
+import { useChatPropatiesContext } from "./ChatPropatiesContext";
+import { useActionState } from "react";
 
 export default function Project({ project_id }) {
     const navigate = useNavigate();
@@ -11,15 +13,13 @@ export default function Project({ project_id }) {
     const [ProjectName, setProjectName] = useState("");
     const [ProjectDescription, setProjectDescription] = useState("");
     const {setCurrentProjectID} = useIdListContext();
+    const { set_project_name, set_project_description, set_ai_role } = useChatPropatiesContext();
 
     const GotoMeetingPage = () => {
         setCurrentProjectID(project_id);
-        navigate("/MeetingPage", {
-            state: {
-                projectName: ProjectName,
-                projectDescription: ProjectDescription,
-            },
-        });
+        set_project_name(ProjectName);
+        set_project_description(ProjectDescription);
+        navigate("/MeetingPage");
     }
 
     // プロジェクト情報を取得する関数
@@ -40,6 +40,7 @@ export default function Project({ project_id }) {
                 const data = await response.json();
                 setProjectName(data.project_name);
                 setProjectDescription(data.project_description);
+                set_ai_role(data.ai_role)
                 console.log("Project Info:", { ProjectName, ProjectDescription });
             } else {
                 throw new Error(`Error: ${response.status}`);

--- a/dev/frontend/react_app/src/components/ProjectCreate.jsx
+++ b/dev/frontend/react_app/src/components/ProjectCreate.jsx
@@ -6,10 +6,6 @@ import { useUserAuthContext } from "./UserAuthContext";
 
 
 export default function ProjectCreate() {
-    const navigate = useNavigate();
-    const GotoMeetingPage = () => {
-        navigate("/MeetingPage")
-    }
     const [percentage1, setPercentage1] = useState(50);
     const [percentage2, setPercentage2] = useState(50);
     const [percentage3, setPercentage3] = useState(50);
@@ -48,7 +44,8 @@ export default function ProjectCreate() {
                         "user_id": UserID,
                         "project_id": project_id,
                         "project_name": ProjectName,
-                        "project_description": ProjectDescription
+                        "project_description": ProjectDescription,
+                        "ai_role": AIsRole
                 }),
             });
 

--- a/dev/frontend/react_app/src/components/WhiteBoard.jsx
+++ b/dev/frontend/react_app/src/components/WhiteBoard.jsx
@@ -1,19 +1,43 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useChatPropatiesContext } from "./ChatPropatiesContext";
 
 export const Whiteboard = () => {
   const [cards, setCards] = React.useState({
-    id0: { text: "ID0message", x: 100, y: 100, backgroundColor:"yellow" },
-    id1: { text: "ID1message", x: 200, y: 300, backgroundColor:"yellow" },
   });
   const updateCard = (cardId, cardData) => setCards({ ...cards, [cardId]: cardData });
   const addCard = () => {
-    const newid = `id${Object.keys(cards).length}`
-    setCards({...cards, [newid]: { text: `${newid}message`, x: 300, y: 300, backgroundColor:"yellow"  }});
+    const { v4: uuidv4 } = require('uuid');
+    const newid = uuidv4();
+    setCards({ ...cards, [newid]: { text: "新規", x: 300, y: 300, backgroundColor: "yellow" } });
     console.log(cards)
   };
+  
 
   const [draggingCard, setDraggingCard] = React.useState({ id: "", offsetX: 0, offsetY: 0 });
   const [editMode, setEditMode] = React.useState({ id: "" });
+  const { GotIdea, OnBoardIdea, setIdeaOnBoard } = useChatPropatiesContext();
+  const ReDraw = async() => {
+    if (GotIdea.length !== 0) {
+      for (const text of GotIdea.flat()) {
+        const { v4: uuidv4 } = require("uuid");
+        const newid = uuidv4();
+        setCards((prevCards) => ({
+          ...prevCards,
+          [newid]: { text: text, x: 300, y: 300, backgroundColor: "yellow" },
+        }));
+      }
+    };
+  };
+
+  useEffect(() => {
+    ReDraw();
+  }, [GotIdea]);
+
+  useEffect(() => {
+    const texts = Object.values(cards).map((card) => card.text);
+    console.log("textsss", {texts});
+    setIdeaOnBoard(texts);
+  }, [cards]);
 
   return (
     <div
@@ -55,7 +79,7 @@ export const Whiteboard = () => {
             textAlign: "center",
             overflow: "hidden",
             boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)"
-  
+
           }}
           draggable={true}
           onDragStart={(e) =>
@@ -65,7 +89,7 @@ export const Whiteboard = () => {
               offsetY: e.clientY - cards[cardId].y,
             })
           }
-        >         
+        >
           {editMode.id === cardId ? (
             <textarea
               onBlur={() => setEditMode({ id: "" })}
@@ -77,7 +101,7 @@ export const Whiteboard = () => {
           )}
         </div>
       ))}
-      <button onClick={addCard} style={{fontSize:'40px', position:'absolute', left:0, width: '50px', height:'50px'}}>+</button>
+      <button onClick={addCard} style={{ fontSize: '40px', position: 'absolute', left: 0, width: '50px', height: '50px' }}>+</button>
     </div>
   );
 };


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: [フロント側からアイデアの一覧を送受信できるようにする](https://www.notion.so/Q1-14cc5dbe3ed380d4a411d7964f8fdd45?p=6fc5ea792476408dbf7df1b518bd2d87&pm=s)


<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
フロントからAIに質問時、ホワイトボード上の付箋を加味して質問に回答できるようになりました。また、AIがアイデアの発散を判断した場合は発散したアイデアを付箋に反映して表示する。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- AIの役割を登録するエンドポイントが存在しなかったため、追加で作成した


# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
アイデアの収束の結果が返ってこない。おそらく、backend側のバグ？


# おこなった動作確認
- プロジェクト作成画面
![スクリーンショット 2025-01-28 023217](https://github.com/user-attachments/assets/1487f8a4-c88f-4144-8c44-cb1d0933cfb8)
- 会議作成画面（作成画面のスクショを忘れたため、作成済みのルームカードで）
![image](https://github.com/user-attachments/assets/35d222b7-f3d7-4e83-87a0-5b82a2234522)
- ユーザーが考えたアイデアを付箋に出しておく
![スクリーンショット 2025-01-28 023925](https://github.com/user-attachments/assets/c4b01f2f-8002-4bde-9e69-1e50d7f9c8e3)
- AIに質問し、付箋が出力される
![スクリーンショット 2025-01-28 023951](https://github.com/user-attachments/assets/a4cc374d-1178-4e6d-aeaf-d256512feb12)

