### PR TITLE
会議スケジュール表示、タイマー機能の追加

### DIFF
--- a/dev/backend/api/schema.py
+++ b/dev/backend/api/schema.py
@@ -247,6 +247,7 @@ class MeetingItem(BaseModel):
     meeting_id: str
     meeting_name: str
     meeting_description: str
+    
 
 
 class UserItem(BaseModel):

--- a/dev/frontend/react_app/src/components/AIAgentsImage.jsx
+++ b/dev/frontend/react_app/src/components/AIAgentsImage.jsx
@@ -9,6 +9,7 @@ import ChatDrawer from './ChatDrawer';
 import { useDrawerContext } from './DrawerContext';
 import { useFastAPIContext } from "./FastAPIContext";
 import { useChatPropatiesContext } from "./ChatPropatiesContext";
+import { useIdListContext } from "./IdListContext";
 
 export default function AIAgentsImage() {
     const { micmute, SetMute, toggleListening, questionstartListening, stopListening } = useMicContext();
@@ -17,6 +18,7 @@ export default function AIAgentsImage() {
     const { AIMessage, SetAIMessage, addDocuments } = useFastAPIContext();
     const [finalTranscript, setFinalTranscript] = useState(""); // 確定した文章
     const timerRef = useRef(null); // タイマーを格納
+    const { CurrentProjectID, CurrentMeetingID } = useIdListContext();
     const { project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time, OnBoardIdea, SetGotIdea } = useChatPropatiesContext();
 
     const imgstyle = {
@@ -54,7 +56,7 @@ export default function AIAgentsImage() {
     const UseFastAPITosendUserMessage = async (message) => {
         try {
 
-            const response = await fetch(`https://${currentHost}/api/chat/111`, {
+            const response = await fetch(`https://${currentHost}/api/chat/${CurrentMeetingID}`, {
                 // const response = await fetch(`http://${currentHost}:8080/chat/111`, {
                 method: "POST",
                 headers: {
@@ -89,7 +91,6 @@ export default function AIAgentsImage() {
                     SetGotIdea(ResponseIdea);
                 }
                 const ResponseMessage = data.chat.message;
-                console.log(data);
                 SetResponseCheck(true);
                 SetAIMessage(ResponseMessage);
                 console.log('Response from API:', ResponseMessage);
@@ -109,7 +110,7 @@ export default function AIAgentsImage() {
 
     const UseFastAPITosendMinutes = async (message) => {
         try {
-            const response = await fetch(`https://${currentHost}/api/minutes/111`, {
+            const response = await fetch(`https://${currentHost}/api/minutes/${CurrentMeetingID}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/AIAgentsImage.jsx
+++ b/dev/frontend/react_app/src/components/AIAgentsImage.jsx
@@ -17,14 +17,20 @@ export default function AIAgentsImage() {
     const { AIMessage, SetAIMessage, addDocuments } = useFastAPIContext();
     const [finalTranscript, setFinalTranscript] = useState(""); // 確定した文章
     const timerRef = useRef(null); // タイマーを格納
-    const {  project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time, OnBoardIdea, SetGotIdea } = useChatPropatiesContext();
+    const { project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time, OnBoardIdea, SetGotIdea } = useChatPropatiesContext();
 
     const imgstyle = {
+        position: 'absolute',
+        top: '15vh',
+        left: '-3vw',
+        width: '25vw',
+        height: '25vh',
         display: 'flex',
-        width: '180px',
-        marginTop: '40px',
-        marginLeft: '40px'
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
     };
+
     const {
         transcript,
         listening,
@@ -43,13 +49,13 @@ export default function AIAgentsImage() {
     };
 
     const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
-    
-    
+
+
     const UseFastAPITosendUserMessage = async (message) => {
         try {
 
             const response = await fetch(`https://${currentHost}/api/chat/111`, {
-            // const response = await fetch(`http://${currentHost}:8080/chat/111`, {
+                // const response = await fetch(`http://${currentHost}:8080/chat/111`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/DrawSchedule.jsx
+++ b/dev/frontend/react_app/src/components/DrawSchedule.jsx
@@ -1,0 +1,61 @@
+export const DrawSchedule = ({ data }) => {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "flex-start",
+          width: "25vw", // 画面幅の1/4
+          height: "70vh", // 画面高さの1/4
+          padding: "10px",
+          overflowY: "auto", // 内容が溢れる場合スクロール可能
+          position: "absolute",
+          top: "10vh", // 画面下部
+          right: "1vw", // 画面右端
+          backgroundColor: "#f4f4f4", // 背景色
+          border: "1px solid #ccc", // 境界線
+          borderRadius: "8px", // 角丸
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)", // 影
+        }}
+      >
+        <div style={{ width: "100%" }}>
+          <h1
+            style={{
+              color: "#333",
+              fontSize: "18px", // 見出しの文字サイズを小さく調整
+              marginBottom: "10px",
+            }}
+          >
+            Task Schedule
+          </h1>
+          {data.TaskList.map((task, index) => (
+            <div
+              key={index}
+              style={{
+                backgroundColor: "#fff",
+                borderRadius: "8px",
+                boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+                marginBottom: "10px",
+                padding: "10px",
+                textAlign: "left",
+              }}
+            >
+              <h2 style={{ color: "#007BFF", fontSize: "16px" }}>{task.name}</h2>
+              <p style={{ fontSize: "14px", color: "#555" }}>{task.description}</p>
+              <p
+                style={{
+                  fontSize: "14px",
+                  fontWeight: "bold",
+                  color: "#333",
+                  marginTop: "5px",
+                }}
+              >
+                Time: <span style={{ color: "#e74c3c" }}>{task.metadata.time} seconds</span>
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+  

--- a/dev/frontend/react_app/src/components/IdListContext.jsx
+++ b/dev/frontend/react_app/src/components/IdListContext.jsx
@@ -18,12 +18,14 @@ export const IdListProvider = ({ children }) => {
         setALLMeetingIdList(new_meeting);
     };
 
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
 
     // ユーザーIDを基に全プロジェクトIDを取得する
     const GetALLProjectId = async({user_id}) => {
         
         try {
-            const response = await fetch("http://localhost:8080/FB/GetALLProjectId", {
+            const response = await fetch(`https://${currentHost}/api/FB/GetALLProjectId`, {
+            // const response = await fetch("http://localhost:8080/FB/GetALLProjectId", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -47,7 +49,8 @@ export const IdListProvider = ({ children }) => {
     // 2つのIDを基に全ミーティングIDを取得する
     const GetALLMeetingId = async({user_id, project_id}) => {
         try {
-            const response = await fetch("http://localhost:8080/FB/GetALLMeetingId", {
+            const response = await fetch(`https://${currentHost}/api/FB/GetALLMeetingId`, {
+            // const response = await fetch("http://localhost:8080/FB/GetALLMeetingId", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/Meeting.jsx
+++ b/dev/frontend/react_app/src/components/Meeting.jsx
@@ -19,12 +19,14 @@ export default function Meeting({meeting_id}) {
     const [MeetingDescription, setMeetingDescription] = useState("");
     const { CurrentProjectID } = useIdListContext();
     const {loginUser} = useUserAuthContext();
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
     
 
     // プロジェクト情報を取得する関数
     const GetMeetingInfoFromId = async () => {
         try {
-            const response = await fetch("http://localhost:8080/FB/GetMeetingInfoFromId", {
+            const response = await fetch(`https://${currentHost}/api/FB/GetMeetingInfoFromId`, {
+            // const response = await fetch("http://localhost:8080/FB/GetMeetingInfoFromId", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/MeetingDetails.jsx
+++ b/dev/frontend/react_app/src/components/MeetingDetails.jsx
@@ -12,11 +12,14 @@ export default function MeetingDetails() {
 
     const { loginUser } = useUserAuthContext();
     const { CurrentProjectID } = useIdListContext();
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
+    
 
     // プロジェクト情報を取得する関数
     const GetProjectInfoFromId = async () => {
         try {
-            const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
+            const response = await fetch(`https://${currentHost}/api/FB/GetProjectInfoFromId`, {
+            // const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/MeetingList.css
+++ b/dev/frontend/react_app/src/components/MeetingList.css
@@ -1,6 +1,6 @@
 .MeetingList_container {
     width: 900px;
-    height: 410px;
+    height: 160px;
     background-color: rgb(255, 255, 255);
     overflow-y: auto;
     scrollbar-width: none;

--- a/dev/frontend/react_app/src/components/MeetingList.jsx
+++ b/dev/frontend/react_app/src/components/MeetingList.jsx
@@ -16,7 +16,7 @@ export default function MeetingList() {
     const { loginUser } = useUserAuthContext();
 
     const update = () => {
-        GetALLMeetingId({user_id: loginUser.uid, project_id: CurrentProjectID});
+        GetALLMeetingId({ user_id: loginUser.uid, project_id: CurrentProjectID });
     };
     useEffect(() => {
         update();
@@ -24,9 +24,9 @@ export default function MeetingList() {
     }, []);
 
     return (
-        <div>
+        <div style={{ maxHeight: '60vh', overflowY: 'auto' }}>
             {ALLMeetingIdList.flat().map((meeting_id) => (
-                            <Meeting meeting_id={meeting_id} />
+                <Meeting key={meeting_id} meeting_id={meeting_id} />
             ))}
         </div>
     );

--- a/dev/frontend/react_app/src/components/MeetingPopup.jsx
+++ b/dev/frontend/react_app/src/components/MeetingPopup.jsx
@@ -13,13 +13,17 @@ export default function MeetingPopup() {
     const [MeetingDescription, setMeetingDescription] = useState("");
     const [MeetingTime, setMeetingTime] = useState("");
     const { GetALLMeetingId, CurrentProjectID, setCurrentProjectID, CurrentMeetingID, setCurrentMeetingID } = useIdListContext();
-    const {  set_meeting_name, set_meeting_description, set_maximum_time, project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time } = useChatPropatiesContext();
+    const { set_meeting_name, set_meeting_description, set_maximum_time, project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time } = useChatPropatiesContext();
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
+
 
     const ClickedCreateProject = async() => {
         const { v4: uuidv4 } = require('uuid');
         const meeting_id = uuidv4();
         try {
-            const response = await fetch("http://localhost:8080/FB/WriteMeetingId", {
+            const response = await fetch(`https://${currentHost}/api/FB/WriteMeetingId`, {
+            // const response = await fetch("http://localhost:8080/FB/WriteMeetingId", {
+            
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -49,7 +53,8 @@ export default function MeetingPopup() {
         }
         // スケジュール作成
         try {
-            const response = await fetch("http://localhost:8080/InitializeMeeting/111", {
+            const response = await fetch(`https://${currentHost}/api/InitializeMeeting/${CurrentMeetingID}`, {
+            // const response = await fetch(`http://localhost:8080/InitializeMeeting/${CurrentMeetingID}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -89,7 +94,7 @@ export default function MeetingPopup() {
                         <textarea placeholder="会議目標と内容を入力してください" className="input-textarea" value={MeetingDescription} onChange={(e) => setMeetingDescription(e.target.value)}/>
                     </div>
                     <div className="Create_time">
-                        <textarea placeholder="会議の時間" className="input-textarea" value={MeetingTime} onChange={(e) => setMeetingTime(e.target.value)}/>
+                        <textarea placeholder="会議の時間/分" className="input-textarea" value={MeetingTime} onChange={(e) => setMeetingTime(e.target.value)}/>
                     </div>
                     <div>
                         <button className="create-button" onClick={ClickedCreateProject}>会議を開く</button>

--- a/dev/frontend/react_app/src/components/MeetingPopup.jsx
+++ b/dev/frontend/react_app/src/components/MeetingPopup.jsx
@@ -13,7 +13,7 @@ export default function MeetingPopup() {
     const [MeetingDescription, setMeetingDescription] = useState("");
     const [MeetingTime, setMeetingTime] = useState("");
     const { GetALLMeetingId, CurrentProjectID, setCurrentProjectID, CurrentMeetingID, setCurrentMeetingID } = useIdListContext();
-    const { set_meeting_name, set_meeting_description, set_maximum_time } = useChatPropatiesContext();
+    const {  set_meeting_name, set_meeting_description, set_maximum_time, project_name, project_description, meeting_name, meeting_description, ai_role, maximum_time } = useChatPropatiesContext();
 
     const ClickedCreateProject = async() => {
         const { v4: uuidv4 } = require('uuid');
@@ -40,9 +40,35 @@ export default function MeetingPopup() {
                 set_meeting_description(MeetingDescription);
                 GetALLMeetingId({user_id: loginUser.uid, project_id: CurrentProjectID});
                 set_maximum_time(MeetingTime);
-                navigate("/DiscussPage");
             } else {
                 alert("Fail create project");
+                throw new Error(`Error: ${response.status}`);
+            }
+        } catch (error) {
+            console.error("Failed to send transcript to API:", error);
+        }
+        // スケジュール作成
+        try {
+            const response = await fetch("http://localhost:8080/InitializeMeeting/111", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "project_name": project_name,
+                    "project_description": project_description,
+                    "meeting_name": MeetingName,
+                    "meeting_description": MeetingDescription,
+                    "ai_role": ai_role,
+                    "maximum_time": parseInt(MeetingTime, 10)
+                  }),
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                navigate("/DiscussPage", { state: { data } });
+            } else {
+                alert("Fail initialize");
                 throw new Error(`Error: ${response.status}`);
             }
         } catch (error) {

--- a/dev/frontend/react_app/src/components/Project.jsx
+++ b/dev/frontend/react_app/src/components/Project.jsx
@@ -14,6 +14,8 @@ export default function Project({ project_id }) {
     const [ProjectDescription, setProjectDescription] = useState("");
     const {setCurrentProjectID} = useIdListContext();
     const { set_project_name, set_project_description, set_ai_role } = useChatPropatiesContext();
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
+
 
     const GotoMeetingPage = () => {
         setCurrentProjectID(project_id);
@@ -25,7 +27,9 @@ export default function Project({ project_id }) {
     // プロジェクト情報を取得する関数
     const GetProjectInfoFromId = async () => {
         try {
-            const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
+            const response = await fetch(`https://${currentHost}/api/FB/GetProjectInfoFromId`, {
+            // const response = await fetch("http://localhost:8080/FB/GetProjectInfoFromId", {
+            
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/ProjectCreate.jsx
+++ b/dev/frontend/react_app/src/components/ProjectCreate.jsx
@@ -30,12 +30,16 @@ export default function ProjectCreate() {
     const [ProjectDescription, setProjectDescription] = useState("");
     const [AIsRole, setAIsRole] = useState("");
     const { GetALLProjectId, setCurrentProjectID } = useIdListContext();
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
+
 
     const ClickedCreateProject = async() => {
         const { v4: uuidv4 } = require('uuid');
         const project_id = uuidv4();
         try {
-            const response = await fetch("http://localhost:8080/FB/WriteProjectId", {
+            const response = await fetch(`https://${currentHost}/api/FB/WriteProjectId`, {
+            // const response = await fetch("http://localhost:8080/FB/WriteProjectId", {
+            
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/SignUpForm.jsx
+++ b/dev/frontend/react_app/src/components/SignUpForm.jsx
@@ -14,7 +14,7 @@ export default function SignUpForm() {
     const [password, setPassword] = useState("")
 
     const { loginUser, login_google, login_email, logout } = useUserAuthContext();
-
+    const currentHost = window.location.hostname;  // ホスト名（ドメイン名）
 
     const Clicksignup = async () => {
         try {
@@ -32,7 +32,9 @@ export default function SignUpForm() {
 
     const SendUserId = async(userId) => {
         try {
-            const response = await fetch("http://localhost:8080/FB/WriteUserId", {
+            const response = await fetch(`https://${currentHost}/api/FB/WriteUserId`, {
+            // const response = await fetch("http://localhost:8080/FB/WriteUserId", {
+            
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/dev/frontend/react_app/src/components/Timer.jsx
+++ b/dev/frontend/react_app/src/components/Timer.jsx
@@ -4,13 +4,13 @@ import FacebookCircularProgress from "./TimerCircle";
 import { TimerValue } from "./TimerValue";
 import { TimerTest } from "./TimerTest";
 
-export const Timer = () => {
+export const Timer = ({timelist}) => {
     return (
         <div>
             {/* <TimerStringLetter></TimerStringLetter>
             <FacebookCircularProgress></FacebookCircularProgress>
             <TimerValue></TimerValue> */}
-            <TimerTest></TimerTest>
+            <TimerTest timelist={timelist}></TimerTest>
         </div>
     );
 };

--- a/dev/frontend/react_app/src/components/TimerTest.jsx
+++ b/dev/frontend/react_app/src/components/TimerTest.jsx
@@ -2,17 +2,13 @@ import React, { useState, useEffect } from 'react';
 import './TimerTest_01.css';
 import './TimerTest_02.css';
 
-export function TimerTest() {
+export function TimerTest({ timelist }) {
   const [mode, setMode] = useState('pomo');
-  const [isTimerRunning, setIsTimerRunning] = useState(false);
-  const [timeLeft, setTimeLeft] = useState(25 * 60);
+  const [timeLeft, setTimeLeft] = useState(timelist[0] || 0);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [circleDashOffset, setCircleDashOffset] = useState(0);
 
-  const totalTime = mode === 'pomo' ? 25 * 60 : mode === 'short' ? 5 * 60 : 15 * 60;
-
-  const toggleTimer = () => {
-    setIsTimerRunning(prevState => !prevState);
-  };
+  const totalTime = timeLeft;
 
   const handleModeChange = (event) => {
     setMode(event.target.value);
@@ -28,54 +24,55 @@ export function TimerTest() {
   };
 
   useEffect(() => {
-    if (isTimerRunning && timeLeft > 0) {
-      const timerId = setInterval(() => {
+    const timerId = setInterval(() => {
+      if (timeLeft > 0) {
         setTimeLeft(prevTime => prevTime - 1);
-      }, 1000);
-      return () => clearInterval(timerId);
-    }
-  }, [isTimerRunning, timeLeft]);
+      } else if (timeLeft === 0 && currentIndex < timelist.length - 1) {
+        setCurrentIndex(prevIndex => prevIndex + 1);
+        setTimeLeft(timelist[currentIndex + 1]);
+      }
+    }, 1000);
+
+    return () => clearInterval(timerId);
+  }, [timeLeft, currentIndex, timelist]);
 
   useEffect(() => {
     const offset = (1 - timeLeft / totalTime) * 301.593;
     setCircleDashOffset(offset);
   }, [timeLeft]);
 
+  const containerStyle = {
+    position: 'absolute',
+    top: '50vh',
+    left: '1vw',
+    width: '15vw',
+    height: '15vh',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+  };
+
   return (
-    <div className="pomodoro-app">
-      <form className="controls">
-        <input
-          type="radio"
-          id="pomo"
-          name="mode"
-          value="pomo"
-          checked={mode === 'pomo'}
-          onChange={handleModeChange}
-        />
-        <label htmlFor="pomo" className="controls__button">Pomodoro</label>
+    <div className="pomodoro-app" style={{ position: 'relative' }}>
+      <div style={{
+        position: 'absolute',
+        top: '40vh',
+        left: '1vw',
+        width: '15vw',
+        height: '10vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+        fontSize: '36px',
+        color: '#4a90e2',
+        fontWeight: 'bold'
+      }}>
+        Step {currentIndex + 1} of {timelist.length}
+      </div>
 
-        <input
-          type="radio"
-          id="short"
-          name="mode"
-          value="short"
-          checked={mode === 'short'}
-          onChange={handleModeChange}
-        />
-        <label htmlFor="short" className="controls__button">Short Break</label>
-
-        <input
-          type="radio"
-          id="long"
-          name="mode"
-          value="long"
-          checked={mode === 'long'}
-          onChange={handleModeChange}
-        />
-        <label htmlFor="long" className="controls__button">Long Break</label>
-      </form>
-
-      <div className="timer" onClick={toggleTimer}>
+      <div className="timer" style={containerStyle}>
         <div className="timer__display">
           <div data-test-id="CircularProgressbarWithChildren">
             <div style={{ position: 'relative', width: '100%', height: '100%' }}>
@@ -111,7 +108,7 @@ export function TimerTest() {
                   className="CircularProgressbar-text"
                   x="50"
                   y="50"
-                  style={{ fill:'#000000' , fontSize: '28px' }}
+                  style={{ fill: '#000000', fontSize: '28px' }}
                 >
                   {formatTime(timeLeft)}
                 </text>
@@ -134,6 +131,7 @@ export function TimerTest() {
                   className="display__mute"
                   id="muteButton"
                   title="mute button"
+                  disabled
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -150,8 +148,8 @@ export function TimerTest() {
                   </svg>
                 </button>
 
-                <button className="display__start-pause">
-                  {isTimerRunning ? 'PAUSE' : 'START'}
+                <button className="display__start-pause" disabled>
+                  START
                 </button>
               </div>
             </div>

--- a/dev/frontend/react_app/src/components/ToolBar.jsx
+++ b/dev/frontend/react_app/src/components/ToolBar.jsx
@@ -72,8 +72,6 @@ export default function ToolBar() {
                     <SettingsIcon style={{ color: 'white' }} />
                 </IconButton></Item>
             </Stack>
-            {/* 議事録 */}
-            <p>{transcript}</p>
         </div>
     );
 };

--- a/dev/frontend/react_app/src/components/WhiteBoard.jsx
+++ b/dev/frontend/react_app/src/components/WhiteBoard.jsx
@@ -2,31 +2,29 @@ import React, { useEffect, useState } from "react";
 import { useChatPropatiesContext } from "./ChatPropatiesContext";
 
 export const Whiteboard = () => {
-  const [cards, setCards] = React.useState({
-  });
+  const [cards, setCards] = React.useState({});
   const updateCard = (cardId, cardData) => setCards({ ...cards, [cardId]: cardData });
   const addCard = () => {
-    const { v4: uuidv4 } = require('uuid');
+    const { v4: uuidv4 } = require("uuid");
     const newid = uuidv4();
-    setCards({ ...cards, [newid]: { text: "新規", x: 300, y: 300, backgroundColor: "yellow" } });
-    console.log(cards)
+    setCards({ ...cards, [newid]: { text: "新規", x: 100, y: 100, backgroundColor: "yellow" } });
   };
-  
 
   const [draggingCard, setDraggingCard] = React.useState({ id: "", offsetX: 0, offsetY: 0 });
   const [editMode, setEditMode] = React.useState({ id: "" });
   const { GotIdea, OnBoardIdea, setIdeaOnBoard } = useChatPropatiesContext();
-  const ReDraw = async() => {
+
+  const ReDraw = async () => {
     if (GotIdea.length !== 0) {
       for (const text of GotIdea.flat()) {
         const { v4: uuidv4 } = require("uuid");
         const newid = uuidv4();
         setCards((prevCards) => ({
           ...prevCards,
-          [newid]: { text: text, x: 300, y: 300, backgroundColor: "yellow" },
+          [newid]: { text: text, x: 100, y: 100, backgroundColor: "yellow" },
         }));
       }
-    };
+    }
   };
 
   useEffect(() => {
@@ -35,31 +33,35 @@ export const Whiteboard = () => {
 
   useEffect(() => {
     const texts = Object.values(cards).map((card) => card.text);
-    console.log("textsss", {texts});
     setIdeaOnBoard(texts);
   }, [cards]);
 
   return (
     <div
       style={{
-        width: "1000px",
-        height: "580px",
-        position: "absolute",
-        top: "100px",
-        left: "280px",
-        backgroundColor: "#ececec",
-        overflow: "hidden"
+        width: "50vw", // 画面幅の2,3分割目に相当する幅 (画面の半分)
+        height: "80vh", // 高さは90%とする
+        position: "absolute", // 絶対配置
+        top: "10vh", // 上部から5%の位置
+        left: "20vw", // 左から2分割目の開始位置
+        backgroundColor: "#ececec", // 背景色
+        overflowY: "auto", // 縦スクロールを有効化
+        border: "1px solid #ccc", // 境界線
+        borderRadius: "8px", // 角を丸くする
+        boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)", // 影
+        zIndex: 1000, // 他の要素より前面に表示
       }}
+      onClick={(e) => e.stopPropagation()} // クリックイベントの伝播を停止
       onDrop={(e) => {
+        e.stopPropagation(); // ドロップイベントの伝播を停止
         if (!draggingCard.id || !cards[draggingCard.id]) return;
         updateCard(draggingCard.id, {
           ...cards[draggingCard.id],
           x: e.clientX - draggingCard.offsetX,
           y: e.clientY - draggingCard.offsetY,
         });
-        console.log({ ...cards[draggingCard.id] });
       }}
-      onDragOver={(e) => e.preventDefault()} // enable onDrop event
+      onDragOver={(e) => e.preventDefault()}
     >
       {Object.keys(cards).map((cardId) => (
         <div
@@ -78,8 +80,7 @@ export const Whiteboard = () => {
             alignItems: "center",
             textAlign: "center",
             overflow: "hidden",
-            boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)"
-
+            boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
           }}
           draggable={true}
           onDragStart={(e) =>
@@ -101,7 +102,20 @@ export const Whiteboard = () => {
           )}
         </div>
       ))}
-      <button onClick={addCard} style={{ fontSize: '40px', position: 'absolute', left: 0, width: '50px', height: '50px' }}>+</button>
+      <button
+        onClick={addCard}
+        style={{
+          fontSize: "40px",
+          position: "absolute",
+          left: "5px",
+          top: "5px",
+          width: "50px",
+          height: "50px",
+        }}
+      >
+        +
+      </button>
     </div>
   );
+  
 };

--- a/dev/frontend/react_app/src/pages/DiscussPage.jsx
+++ b/dev/frontend/react_app/src/pages/DiscussPage.jsx
@@ -9,8 +9,6 @@ import { useLocation } from "react-router-dom";
 import { DrawSchedule } from "../components/DrawSchedule";
 
 
-
-
 const DiscussPage = () =>{
     const location = useLocation();
     const data = location.state?.data; // 渡されたデータを取得

--- a/dev/frontend/react_app/src/pages/DiscussPage.jsx
+++ b/dev/frontend/react_app/src/pages/DiscussPage.jsx
@@ -5,16 +5,25 @@ import { Timer } from "../components/Timer";
 import ToolBar from "../components/ToolBar";
 import CallEnd from "../components/CallEnd";
 import { Whiteboard } from "../components/WhiteBoard";
+import { useLocation } from "react-router-dom";
+import { DrawSchedule } from "../components/DrawSchedule";
 
 
 
 
 const DiscussPage = () =>{
+    const location = useLocation();
+    const data = location.state?.data; // 渡されたデータを取得
+    console.log(data);
+    const timeList = data.TaskList.map((task) => task.metadata.time);
+
+
     return (
         <div>
             <MainAppBar></MainAppBar>
             <AIAgentsImage></AIAgentsImage>
-            <Timer></Timer>
+            <Timer timelist={timeList}></Timer>
+            <DrawSchedule data={data}></DrawSchedule>
             <ToolBar></ToolBar>
             <CallEnd></CallEnd>
             <Whiteboard></Whiteboard>


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: [会議スケジュール表示、タイマー機能の追加](https://www.notion.so/Q1-14cc5dbe3ed380d4a411d7964f8fdd45?p=c85b92fd97564bfba1fb9a103f699caf&pm=s)

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
会議のスケジュールを取得し、DiscussPageに表示しました。また、各タスクの時間を取得し、タイマーとして表示しました。現在どのフェーズにいるのかわかりやすくするために、フェーズ番号も表示しました。


# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- apiのリンクをlocalhostからHostingアドレスに変更
- 会議一覧ページの会議カードの表示バグを修正
- DiscussPageの各コンポーネントを画面全体の比率で表示されるように変更。形が崩れなくなった。



# 影響範囲・懸念点

会議スケジュールの見た目をもう少し整えたい


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
* 会議スケジュールの作成及び、表示 


